### PR TITLE
Add game roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # Rhythm
+
+## Game Roadmap
+
+1. **Pre-production**
+   - Define the core concept and gameplay goals.
+   - Select tools and technologies for development.
+   - Outline initial art and audio direction.
+
+2. **Prototype**
+   - Implement a minimal playable prototype focusing on the beat-matching mechanic.
+   - Integrate placeholder assets for quick iteration.
+   - Validate the fun factor through early testing.
+
+3. **Production**
+   - Create final art, music, and sound effects.
+   - Expand level content and refine game mechanics.
+   - Implement scoring, combos, and difficulty settings.
+
+4. **Testing**
+   - Conduct internal playtesting to polish gameplay.
+   - Fix bugs and optimize performance across target platforms.
+
+5. **Launch**
+   - Prepare marketing material and publish the game.
+   - Gather player feedback and monitor stability.
+
+6. **Post-launch**
+   - Release updates with new songs and features.
+   - Continue community engagement and support.
+
+## Gameplay Loop
+
+- Built around short rhythm mini-games similar to **Rhythm Heaven**.
+- Each stage opens with a quick practice so players learn the rhythm.
+- Tap or press buttons in sync with the beat during the main section.
+- Accuracy is graded as *Perfect*, *Good*, or *Miss* and rolled into a final rank.
+- Results show ranks like "Superb," "OK," or "Try Again," unlocking the next stage when cleared.


### PR DESCRIPTION
## Summary
- expand README with a simple roadmap for developing the rhythm game
- document gameplay loop similar to Rhythm Heaven

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6863eaac0ba08326931063f0a7434f84