### PR TITLE
Add basic rhythm prototype with scoring system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rhythm
 
+A simple rhythm game prototype written in Python. The repository now includes placeholder directories for final art, music, and sound effects as well as a minimal game script that supports scoring, combo tracking, and difficulty settings.
+
 ## Game Roadmap
 
 1. **Pre-production**
@@ -13,7 +15,7 @@
    - Validate the fun factor through early testing.
 
 3. **Production**
-   - Create final art, music, and sound effects.
+   - Create final art, music, and sound effects (see `assets/`).
    - Expand level content and refine game mechanics.
    - Implement scoring, combos, and difficulty settings.
 
@@ -36,3 +38,9 @@
 - Tap or press buttons in sync with the beat during the main section.
 - Accuracy is graded as *Perfect*, *Good*, or *Miss* and rolled into a final rank.
 - Results show ranks like "Superb," "OK," or "Try Again," unlocking the next stage when cleared.
+
+## Directory Overview
+
+- `src/` – Contains the Python prototype. Run `python src/main.py levels/level1.json` to play.
+- `assets/art/`, `assets/music/`, `assets/sfx/` – Placeholders for final game assets.
+- `levels/` – JSON files describing beat timings and level metadata.

--- a/assets/art/README.md
+++ b/assets/art/README.md
@@ -1,0 +1,1 @@
+Placeholder for final art assets.

--- a/assets/music/README.md
+++ b/assets/music/README.md
@@ -1,0 +1,1 @@
+Placeholder for final music assets.

--- a/assets/sfx/README.md
+++ b/assets/sfx/README.md
@@ -1,0 +1,1 @@
+Placeholder for final sound effect assets.

--- a/levels/level1.json
+++ b/levels/level1.json
@@ -1,0 +1,1 @@
+{"level": 1, "name": "Tutorial", "beats": [1, 2, 3, 4]}

--- a/levels/level2.json
+++ b/levels/level2.json
@@ -1,0 +1,1 @@
+{"level": 2, "name": "Main Stage", "beats": [1, 1.5, 2, 2.5, 3]}

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,71 @@
+import json
+import time
+from enum import Enum
+
+class Difficulty(Enum):
+    EASY = 'easy'
+    NORMAL = 'normal'
+    HARD = 'hard'
+
+WINDOWS = {
+    Difficulty.EASY: 0.5,
+    Difficulty.NORMAL: 0.3,
+    Difficulty.HARD: 0.15,
+}
+
+class ScoringSystem:
+    def __init__(self):
+        self.score = 0
+        self.combo = 0
+        self.max_combo = 0
+
+    def register_hit(self, accuracy: str):
+        base = {'perfect': 100, 'good': 50, 'miss': 0}[accuracy]
+        if accuracy == 'miss':
+            self.combo = 0
+        else:
+            self.combo += 1
+            self.max_combo = max(self.max_combo, self.combo)
+        self.score += base * max(1, self.combo)
+
+    def __repr__(self):
+        return f"Score: {self.score} | Max Combo: {self.max_combo}"
+
+def load_level(path: str):
+    with open(path) as f:
+        return json.load(f)
+
+def play_level(level_data, difficulty: Difficulty):
+    beats = level_data.get('beats', [])
+    timing_window = WINDOWS[difficulty]
+    scoring = ScoringSystem()
+    print(f"Starting level '{level_data.get('name', 'Unknown')}' on {difficulty.value}")
+    start_time = time.time()
+    for beat in beats:
+        target = start_time + beat
+        while time.time() < target:
+            time.sleep(0.01)
+        input_time = time.time()
+        input("Hit Enter in time with the beat!")
+        delta = abs(input_time - target)
+        if delta <= timing_window / 2:
+            scoring.register_hit('perfect')
+            print('Perfect!')
+        elif delta <= timing_window:
+            scoring.register_hit('good')
+            print('Good!')
+        else:
+            scoring.register_hit('miss')
+            print('Miss!')
+    print(scoring)
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Simple rhythm game prototype')
+    parser.add_argument('level', help='Path to level file')
+    parser.add_argument('--difficulty', choices=[d.value for d in Difficulty], default='normal')
+    args = parser.parse_args()
+
+    level_data = load_level(args.level)
+    difficulty = Difficulty(args.difficulty)
+    play_level(level_data, difficulty)


### PR DESCRIPTION
## Summary
- create directories for final art, music, and sound effects
- add placeholder level data
- implement a minimal Python rhythm game with scoring, combos, and difficulty
- update README with instructions and directory overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863eda8554483269c5d72c9bbb242c8